### PR TITLE
feat: Add unified folder structure support for config organization

### DIFF
--- a/common/src/main/java/dev/toma/configuration/Configuration.java
+++ b/common/src/main/java/dev/toma/configuration/Configuration.java
@@ -81,7 +81,7 @@ public final class Configuration {
         if (group.isEmpty()) {
             group = id;
         }
-        ConfigHolder<CFG> holder = new ConfigHolder<>(cfgClass, id, filename, group, formatFactory);
+        ConfigHolder<CFG> holder = new ConfigHolder<>(cfgClass, id, filename, group, cfg.unifiedfolder(), formatFactory);
         ConfigHolder.registerConfig(holder);
         if (cfgClass.getAnnotation(Config.NoAutoSync.class) == null) {
             ConfigurationFileManager.FILE_WATCH_MANAGER.addTrackedConfig(holder);

--- a/common/src/main/java/dev/toma/configuration/config/Config.java
+++ b/common/src/main/java/dev/toma/configuration/config/Config.java
@@ -47,6 +47,15 @@ public @interface Config {
      * @return Custom config group identifier. By default, value defined by {@link Config#id()} will be used.
      */
     String group() default "";
+	
+	/**
+	 * Determines whether this config should be stored in a unified folder structure.
+	 * When set to {@code true}, the config file will be placed in a subdirectory named after the config group.
+	 * This is useful for organizing multiple related config files together.
+	 *
+	 * @return {@code true} if config should use unified folder structure, {@code false} otherwise
+	 */
+	boolean unifiedfolder() default false;
 
     /**
      * Annotating your config class with this will block config auto-sync when config file is updated

--- a/common/src/main/java/dev/toma/configuration/config/ConfigHolder.java
+++ b/common/src/main/java/dev/toma/configuration/config/ConfigHolder.java
@@ -39,6 +39,8 @@ public final class ConfigHolder<CFG> {
     private final String filename;
     // Config group, same as config ID unless changed
     private final String group;
+	// Whether to use unified folder structure (group-based subdirectory)
+	private final boolean unifiedfolder;
     // Registered config instance
     private final CFG configInstance;
     // Type of config
@@ -54,11 +56,12 @@ public final class ConfigHolder<CFG> {
     // Lock for async operations
     private final Object lock = new Object();
 
-    public ConfigHolder(Class<CFG> cfgClass, String configId, String filename, String group, IConfigFormatHandler format) {
+    public ConfigHolder(Class<CFG> cfgClass, String configId, String filename, String group, boolean unifiedfolder, IConfigFormatHandler format) {
         this.configClass = cfgClass;
         this.configId = configId;
         this.filename = filename;
         this.group = group;
+	    this.unifiedfolder = unifiedfolder;
         try {
             this.configInstance = cfgClass.getDeclaredConstructor().newInstance();
         } catch (NoSuchMethodException | InstantiationException | InvocationTargetException | IllegalAccessException e) {
@@ -230,6 +233,13 @@ public final class ConfigHolder<CFG> {
     public String getGroup() {
         return group;
     }
+	
+	/**
+	 * @return Whether this config uses unified folder structure
+	 */
+	public boolean getUnifiedFolder() {
+		return unifiedfolder;
+	}
 
     /**
      * @return Your registered config

--- a/common/src/main/java/dev/toma/configuration/config/io/ConfigurationFileManager.java
+++ b/common/src/main/java/dev/toma/configuration/config/io/ConfigurationFileManager.java
@@ -115,7 +115,14 @@ public final class ConfigurationFileManager {
 
     public static File getConfigFile(ConfigHolder<?> holder) {
         IConfigFormatHandler handler = holder.getFormat();
-        String filename = holder.getFilename() + "." + handler.fileExt();
+	    String Filename = holder.getFilename();
+	    String groupname = holder.getGroup();
+        String filename;
+	    if (holder.getUnifiedFolder()) {
+		    filename = groupname + "/" + Filename + "." + handler.fileExt();
+	    } else {
+		    filename = Filename + "." + handler.fileExt();
+	    }
         return Paths.get("config", filename).toFile();
     }
 


### PR DESCRIPTION
**Summary:**
This PR introduces an optional unified folder structure that organizes config files into group-based subdirectories, improving file organization for mods with multiple config files.

**Changes:**
- Added `unifiedfolder` attribute to `@Config` annotation (default: false)
- Added corresponding field and getter method in `ConfigHolder`
- Modified `ConfigIO.getConfigFile()` to use group subdirectories when enabled
- Maintains full backward compatibility

**New Behavior:**
- Default (`unifiedfolder = false`): `./config/{filename}.{ext}`
- Enabled (`unifiedfolder = true`): `./config/{groupname}/{filename}.{ext}`

**Usage Example:**
```java
@Config(id = "mymod_client", group = "mymod", unifiedfolder = true)
public class MyModClientConfig {
    // config fields
}

@Config(id = "mymod_server", group = "mymod", unifiedfolder = true)  
public class MyModServerConfig {
    // config fields
}